### PR TITLE
Legger til Accordion og ReadMore i PortableText

### DIFF
--- a/src/components/portable-text-content/PortableTextContent.module.scss
+++ b/src/components/portable-text-content/PortableTextContent.module.scss
@@ -1,0 +1,3 @@
+.whiteSpacePreline {
+  white-space: pre-line;
+}

--- a/src/components/portable-text-content/PortableTextContent.tsx
+++ b/src/components/portable-text-content/PortableTextContent.tsx
@@ -1,6 +1,8 @@
+import { Accordion, ReadMore } from "@navikt/ds-react";
 import { PortableText, PortableTextProps } from "@portabletext/react";
 import { DagpengerKalkulator } from "components/dagpenger-kalkulator/DagpengerKalkulator";
 import { GtoNOK } from "./marks/GtoNOK";
+import styles from "./PortableTextContent.module.scss";
 
 export function PortableTextContent({ value }: PortableTextProps) {
   return (
@@ -10,6 +12,17 @@ export function PortableTextContent({ value }: PortableTextProps) {
         marks: { GtoNOK: GtoNOK },
         types: {
           customComponent: DagpengerKalkulator,
+          produktsideAccordion: ({ value }) => (
+            <Accordion.Item>
+              <Accordion.Header>{value.title}</Accordion.Header>
+              <Accordion.Content className={styles.whiteSpacePreline}>{value.content}</Accordion.Content>
+            </Accordion.Item>
+          ),
+          produktsideReadMore: ({ value }) => (
+            <ReadMore className={styles.whiteSpacePreline} header={value.title} size={value.size}>
+              {value.content}
+            </ReadMore>
+          ),
         },
       }}
     />


### PR DESCRIPTION
- Midlertidige komponenter som skal brukes i innholdssprinten Accordion/ReadMore resolves i PortableText

Relatert PR: https://github.com/navikt/dp-sanity-cms/pull/112